### PR TITLE
make execute via other member

### DIFF
--- a/examples/nft-collections/index.js
+++ b/examples/nft-collections/index.js
@@ -170,14 +170,14 @@ const collectionAndNewNFTExample = () => __awaiter(void 0, void 0, void 0, funct
     });
     const { blockhash, lastValidBlockHeight } = yield squads.connection.getLatestBlockhash("confirmed");
     const executeTx = new web3_js_1.Transaction({
-        feePayer: walletKeypair.publicKey,
+        feePayer: otherMembersBesidesWallet[0].publicKey,
         blockhash,
         lastValidBlockHeight,
     });
     executeTx.add(computeIx);
     executeTx.add(executeIx);
     // sign & serialize and send
-    executeTx.sign(walletKeypair);
+    executeTx.sign(otherMembersBesidesWallet[0]);
     const txid = yield squads.connection.sendRawTransaction(executeTx.serialize(), { skipPreflight: true, preflightCommitment: 'confirmed' });
     console.log("sent execute tx!", txid);
     console.log("finished, check the added nft mint at", newNftMint.toBase58());

--- a/examples/nft-collections/index.ts
+++ b/examples/nft-collections/index.ts
@@ -154,14 +154,14 @@ const collectionAndNewNFTExample = async () => {
     })
     const {blockhash, lastValidBlockHeight} = await squads.connection.getLatestBlockhash("confirmed");
     const executeTx = new Transaction({
-        feePayer: walletKeypair.publicKey,
+        feePayer: otherMembersBesidesWallet[0].publicKey,
         blockhash,
         lastValidBlockHeight,
     });
     executeTx.add(computeIx);
     executeTx.add(executeIx);
     // sign & serialize and send
-    executeTx.sign(walletKeypair);
+    executeTx.sign(otherMembersBesidesWallet[0]);
     const txid = await squads.connection.sendRawTransaction(executeTx.serialize(), {skipPreflight: true, preflightCommitment: 'confirmed'});
     console.log("sent execute tx!", txid);
     console.log("finished, check the added nft mint at", newNftMint.toBase58());


### PR DESCRIPTION
https://solana.fm/address/ER71SVrtEqrATfxGLMoaU2SYgPrP7o6oeiUiGXhy9XtZ/anchor-account?cluster=devnet-solana

This NFT minting transaction can only be executed by the account that creates it, it will be useful to understand if there is a way to create an NFT minting transaction that any member of the multisig can execute